### PR TITLE
임시 로그인 + 팔로우 피드 조회 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
     //mysql
     runtimeOnly 'com.mysql:mysql-connector-j'
+    //security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/goorm/clonestagram/ClonestagramApplication.java
+++ b/src/main/java/com/goorm/clonestagram/ClonestagramApplication.java
@@ -2,7 +2,9 @@ package com.goorm.clonestagram;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ClonestagramApplication {
 

--- a/src/main/java/com/goorm/clonestagram/common/base/BaseTimeEntity.java
+++ b/src/main/java/com/goorm/clonestagram/common/base/BaseTimeEntity.java
@@ -1,4 +1,4 @@
-package com.goorm.clonestagram.user.domain;
+package com.goorm.clonestagram.common.base;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;

--- a/src/main/java/com/goorm/clonestagram/common/exception/ErrorResponseDto.java
+++ b/src/main/java/com/goorm/clonestagram/common/exception/ErrorResponseDto.java
@@ -1,4 +1,4 @@
-package com.goorm.clonestagram.error;
+package com.goorm.clonestagram.common.exception;
 
 import lombok.*;
 

--- a/src/main/java/com/goorm/clonestagram/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/goorm/clonestagram/common/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.goorm.clonestagram.error;
+package com.goorm.clonestagram.common.exception;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/src/main/java/com/goorm/clonestagram/file/controller/FeedController.java
+++ b/src/main/java/com/goorm/clonestagram/file/controller/FeedController.java
@@ -1,0 +1,34 @@
+package com.goorm.clonestagram.file.controller;
+
+import com.goorm.clonestagram.file.dto.FeedResDto;
+import com.goorm.clonestagram.file.service.FeedService;
+import com.goorm.clonestagram.util.TempUserDetail;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+public class FeedController {
+
+    private final FeedService feedService;
+
+    //Todo TempUserDetail 변경
+    @GetMapping("/feeds/me")
+    public ResponseEntity<FeedResDto> myFeed(@AuthenticationPrincipal TempUserDetail userDetail,
+                                             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)Pageable pageable
+
+    ){
+        Long userId = userDetail.getId();
+
+        return ResponseEntity.ok(feedService.getMyFeed(userId,pageable));
+    }
+
+
+}

--- a/src/main/java/com/goorm/clonestagram/file/controller/FeedController.java
+++ b/src/main/java/com/goorm/clonestagram/file/controller/FeedController.java
@@ -39,4 +39,13 @@ public class FeedController {
         return ResponseEntity.ok(feedService.getAllFeed(pageable));
     }
 
+    //Todo TempUserDetail 변경
+    @GetMapping("/feeds/follow")
+    public ResponseEntity<FeedResDto> followFeed(@AuthenticationPrincipal TempUserDetail userDetail,
+                                                 @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)Pageable pageable
+    ){
+        Long userId = userDetail.getId();
+
+        return ResponseEntity.ok(feedService.getFollowFeed(userId, pageable));
+    }
 }

--- a/src/main/java/com/goorm/clonestagram/file/controller/FeedController.java
+++ b/src/main/java/com/goorm/clonestagram/file/controller/FeedController.java
@@ -30,5 +30,13 @@ public class FeedController {
         return ResponseEntity.ok(feedService.getMyFeed(userId,pageable));
     }
 
+    //Todo TempUserDetail 변경
+    @GetMapping("/feeds/all")
+    public ResponseEntity<FeedResDto> allFeed(
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)Pageable pageable
+    ){
+
+        return ResponseEntity.ok(feedService.getAllFeed(pageable));
+    }
 
 }

--- a/src/main/java/com/goorm/clonestagram/file/controller/ImageController.java
+++ b/src/main/java/com/goorm/clonestagram/file/controller/ImageController.java
@@ -5,9 +5,11 @@ import com.goorm.clonestagram.file.dto.ImageUpdateResDto;
 import com.goorm.clonestagram.file.dto.ImageUploadReqDto;
 import com.goorm.clonestagram.file.dto.ImageUploadResDto;
 import com.goorm.clonestagram.file.service.ImageService;
+import com.goorm.clonestagram.util.TempUserDetail;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -28,8 +30,11 @@ public class ImageController {
      * @return 업로드 성공 시 ImageUploadResDto 반환
      * @throws Exception 업로드 도중 발생할 수 있는 예외
      */
+    //Todo TempUserDetail 변경
     @PostMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)//file 업로드를 위해 추가
-    public ResponseEntity<ImageUploadResDto> imageUpload(/*LoginUser loginUser,*/ ImageUploadReqDto imageUploadReqDto) throws Exception {
+    public ResponseEntity<ImageUploadResDto> imageUpload(@AuthenticationPrincipal TempUserDetail userDetail, ImageUploadReqDto imageUploadReqDto) throws Exception {
+
+        Long userId = userDetail.getId();
 
         // 1. 업로드된 파일이 없거나 비어있는 경우 예외 처리
         if(imageUploadReqDto.getFile() == null || imageUploadReqDto.getFile().isEmpty()){
@@ -37,12 +42,12 @@ public class ImageController {
         }
 
         // 2. 업로드된 파일의 Content-Type이 'image/'로 시작하지 않으면 이미지 파일 아님 → 예외 처리
-        if(!imageUploadReqDto.getFile().getContentType().startsWith("image/")){
+        if(!imageUploadReqDto.getFile().getContentType().toLowerCase().startsWith("image/")){
             throw new IllegalArgumentException("이미지를 업로드해 주세요");
         }
 
         // 3. 검증이 통과된 경우 서비스 계층 호출 및 응답 반환
-        return ResponseEntity.ok(imageService.imageUpload(imageUploadReqDto/*, loginUser.getId()*/));
+        return ResponseEntity.ok(imageService.imageUpload(imageUploadReqDto, userId));
     }
 
     /**
@@ -54,14 +59,18 @@ public class ImageController {
      * @param imageUpdateReqDto
      * @return
      */
+    //Todo TempUserDetail 변경
     @PutMapping(value = "/image/{postSeq}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ImageUpdateResDto> imageUpdate(@PathVariable("postSeq") Long postSeq, ImageUpdateReqDto imageUpdateReqDto){
+    public ResponseEntity<ImageUpdateResDto> imageUpdate(@PathVariable("postSeq") Long postSeq,
+                                                         @AuthenticationPrincipal TempUserDetail userDetail,
+                                                         ImageUpdateReqDto imageUpdateReqDto){
+        Long userId = userDetail.getId();
 
-        if(imageUpdateReqDto.getFile() != null && !imageUpdateReqDto.getFile().getContentType().startsWith("image/")){
+        if(imageUpdateReqDto.getFile() != null && !imageUpdateReqDto.getFile().getContentType().toLowerCase().startsWith("image/")){
             throw new IllegalArgumentException("이미지를 업로드해 주세요");
         }
 
-        return ResponseEntity.ok(imageService.imageUpdate(postSeq, imageUpdateReqDto));
+        return ResponseEntity.ok(imageService.imageUpdate(postSeq, imageUpdateReqDto, userId));
     }
 
     /**
@@ -71,10 +80,13 @@ public class ImageController {
      * @param postSeq 삭제할 게시글 식별자
      * @return ResponseEntity
      */
+    //Todo TempUserDetail 변경
     @DeleteMapping("/image/{postSeq}")
-    public ResponseEntity<?> imageDelete(@PathVariable Long postSeq){
+    public ResponseEntity<?> imageDelete(@PathVariable Long postSeq, @AuthenticationPrincipal TempUserDetail userDetail){
 
-        imageService.imageDelete(postSeq);
+        Long userId = userDetail.getId();
+
+        imageService.imageDelete(postSeq, userId);
 
         return ResponseEntity.ok("삭제 완료");
     }

--- a/src/main/java/com/goorm/clonestagram/file/domain/Posts.java
+++ b/src/main/java/com/goorm/clonestagram/file/domain/Posts.java
@@ -1,6 +1,8 @@
 package com.goorm.clonestagram.file.domain;
 
+import com.goorm.clonestagram.common.base.BaseTimeEntity;
 import com.goorm.clonestagram.file.ContentType;
+import com.goorm.clonestagram.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -17,7 +19,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "posts")
-public class Posts {
+public class Posts extends BaseTimeEntity {
 
     /**
      * 게시물 Primary Key
@@ -28,10 +30,9 @@ public class Posts {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-       /** User 객체 대기 **/
-//    @ManyToOne
-//    @Column(name = "user_id", nullable = false)
-//    private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     /**
      * 게시물 내용
@@ -70,4 +71,15 @@ public class Posts {
      */
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/com/goorm/clonestagram/file/dto/FeedResDto.java
+++ b/src/main/java/com/goorm/clonestagram/file/dto/FeedResDto.java
@@ -1,0 +1,14 @@
+package com.goorm.clonestagram.file.dto;
+
+import com.goorm.clonestagram.user.dto.UserProfileDto;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+
+@Getter
+@Builder
+public class FeedResDto {
+    private UserProfileDto user;
+    private Page<PostInfoDto> feed;
+}

--- a/src/main/java/com/goorm/clonestagram/file/dto/ImageUpdateResDto.java
+++ b/src/main/java/com/goorm/clonestagram/file/dto/ImageUpdateResDto.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class ImageUpdateResDto {
-    //    private User user;
     private String content;
     private ContentType type;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/goorm/clonestagram/file/dto/ImageUploadReqDto.java
+++ b/src/main/java/com/goorm/clonestagram/file/dto/ImageUploadReqDto.java
@@ -2,6 +2,7 @@ package com.goorm.clonestagram.file.dto;
 
 import com.goorm.clonestagram.file.ContentType;
 import com.goorm.clonestagram.file.domain.Posts;
+import com.goorm.clonestagram.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -22,13 +23,12 @@ public class ImageUploadReqDto {
     private MultipartFile file;
     private String content;
 
-    public Posts toEntity(String imageName /*, User userEntity*/) {
+    public Posts toEntity(String imageName, User user) {
         return Posts.builder()
-//                    .user(userEntity)
+                .user(user)
                 .content(content)
                 .mediaName(imageName)
                 .contentType(ContentType.IMAGE)
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/goorm/clonestagram/file/dto/ImageUploadResDto.java
+++ b/src/main/java/com/goorm/clonestagram/file/dto/ImageUploadResDto.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class ImageUploadResDto {
-//    private User user;
     private String content;
     private ContentType type;
     private LocalDateTime createdAt;

--- a/src/main/java/com/goorm/clonestagram/file/dto/PostInfoDto.java
+++ b/src/main/java/com/goorm/clonestagram/file/dto/PostInfoDto.java
@@ -1,0 +1,29 @@
+package com.goorm.clonestagram.file.dto;
+
+import com.goorm.clonestagram.file.ContentType;
+import com.goorm.clonestagram.file.domain.Posts;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PostInfoDto {
+    private Long id;
+    private String content;
+    private String mediaName;
+    private ContentType contentType;
+    private LocalDateTime createdAt;
+
+    public static PostInfoDto fromEntity(Posts post) {
+        return PostInfoDto.builder()
+                .id(post.getId())
+                .content(post.getContent())
+                .mediaName(post.getMediaName())
+                .contentType(post.getContentType())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+}
+

--- a/src/main/java/com/goorm/clonestagram/file/dto/VideoUpdateResDto.java
+++ b/src/main/java/com/goorm/clonestagram/file/dto/VideoUpdateResDto.java
@@ -8,7 +8,6 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class VideoUpdateResDto {
-    //    private User user;
     private String content;
     private ContentType type;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/goorm/clonestagram/file/dto/VideoUploadReqDto.java
+++ b/src/main/java/com/goorm/clonestagram/file/dto/VideoUploadReqDto.java
@@ -2,6 +2,7 @@ package com.goorm.clonestagram.file.dto;
 
 import com.goorm.clonestagram.file.ContentType;
 import com.goorm.clonestagram.file.domain.Posts;
+import com.goorm.clonestagram.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -22,13 +23,12 @@ public class VideoUploadReqDto {
     private MultipartFile file;
     private String content;
 
-    public Posts toEntity(String imageName /*, User userEntity*/) {
+    public Posts toEntity(String imageName , User user) {
         return Posts.builder()
-//                    .user(userEntity)
+                .user(user)
                 .content(content)
                 .mediaName(imageName)
                 .contentType(ContentType.VIDEO)
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/goorm/clonestagram/file/dto/VideoUploadResDto.java
+++ b/src/main/java/com/goorm/clonestagram/file/dto/VideoUploadResDto.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class VideoUploadResDto {
-    //    private User user;
     private String content;
     private ContentType type;
     private LocalDateTime createdAt;

--- a/src/main/java/com/goorm/clonestagram/file/repository/PostsRepository.java
+++ b/src/main/java/com/goorm/clonestagram/file/repository/PostsRepository.java
@@ -1,10 +1,16 @@
 package com.goorm.clonestagram.file.repository;
 
 import com.goorm.clonestagram.file.domain.Posts;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 /**
  * Posts와 관련된 JPA
  */
 public interface PostsRepository extends JpaRepository<Posts, Long> {
+    Page<Posts> findAllByUserId(Long userId, Pageable pageable);
+
 }

--- a/src/main/java/com/goorm/clonestagram/file/repository/PostsRepository.java
+++ b/src/main/java/com/goorm/clonestagram/file/repository/PostsRepository.java
@@ -13,4 +13,5 @@ import java.util.List;
 public interface PostsRepository extends JpaRepository<Posts, Long> {
     Page<Posts> findAllByUserId(Long userId, Pageable pageable);
 
+    Page<Posts> findAllByUserIdIn(List<Long> followIds, Pageable pageable);
 }

--- a/src/main/java/com/goorm/clonestagram/file/service/FeedService.java
+++ b/src/main/java/com/goorm/clonestagram/file/service/FeedService.java
@@ -46,4 +46,26 @@ public class FeedService {
                 .build();
     }
 
+    public FeedResDto getFollowFeed(Long userId, Pageable pageable) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("userId = " + userId + " 인 유저가 존재하지 않습니다"));
+
+
+//        Map<Long, Page<Posts>> followFeedMap = new HashMap<>();
+//
+//        List<Follow> followList = user.getFollowing();
+//        for (Follow follow : followList) {
+//            Long followingId = follow.getToUser().getId();
+//            Page<Posts> posts = postsRepository.findAllByUserId(followingId, pageable);
+//            followFeedMap.put(followingId, posts);  // 유저별로 페이지 저장
+//        }
+
+        List<Long> followList = userRepository.findFollowingUserIdsByFromUserId(user.getId());
+        Page<Posts> postsLists = postsRepository.findAllByUserIdIn(followList, pageable);
+
+        return FeedResDto.builder()
+                .user(UserProfileDto.fromEntity(user))
+                .feed(postsLists.map(PostInfoDto::fromEntity))
+                .build();
+    }
 }

--- a/src/main/java/com/goorm/clonestagram/file/service/FeedService.java
+++ b/src/main/java/com/goorm/clonestagram/file/service/FeedService.java
@@ -1,0 +1,40 @@
+package com.goorm.clonestagram.file.service;
+
+import com.goorm.clonestagram.file.domain.Posts;
+import com.goorm.clonestagram.file.dto.FeedResDto;
+import com.goorm.clonestagram.file.dto.PostInfoDto;
+import com.goorm.clonestagram.file.repository.PostsRepository;
+import com.goorm.clonestagram.user.domain.User;
+import com.goorm.clonestagram.user.dto.UserProfileDto;
+import com.goorm.clonestagram.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FeedService {
+
+    private final UserRepository userRepository;
+    private final PostsRepository postsRepository;
+
+    public FeedResDto getMyFeed(Long userId, Pageable pageable) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("userId = " + userId + " 인 유저가 존재하지 않습니다"));
+
+        Page<Posts> myFeed = postsRepository.findAllByUserId(user.getId(), pageable);
+
+        return FeedResDto.builder()
+                .user(UserProfileDto.fromEntity(user))
+                .feed(myFeed.map(PostInfoDto::fromEntity))
+                .build();
+    }
+
+}

--- a/src/main/java/com/goorm/clonestagram/file/service/FeedService.java
+++ b/src/main/java/com/goorm/clonestagram/file/service/FeedService.java
@@ -37,4 +37,13 @@ public class FeedService {
                 .build();
     }
 
+    public FeedResDto getAllFeed(Pageable pageable) {
+        Page<Posts> myFeed = postsRepository.findAll(pageable);
+
+        return FeedResDto.builder()
+                .user(null)
+                .feed(myFeed.map(PostInfoDto::fromEntity))
+                .build();
+    }
+
 }

--- a/src/main/java/com/goorm/clonestagram/file/service/ImageService.java
+++ b/src/main/java/com/goorm/clonestagram/file/service/ImageService.java
@@ -6,8 +6,9 @@ import com.goorm.clonestagram.file.dto.ImageUpdateResDto;
 import com.goorm.clonestagram.file.dto.ImageUploadReqDto;
 import com.goorm.clonestagram.file.dto.ImageUploadResDto;
 import com.goorm.clonestagram.file.repository.PostsRepository;
+import com.goorm.clonestagram.user.domain.User;
+import com.goorm.clonestagram.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,20 +17,19 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 /**
  * 이미지 업로드 요청을 처리하는 서비스
  * - 검증이 완료된 이미지를 받아 업로드 서비스 수행
  */
-@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class ImageService {
 
     private final PostsRepository postsRepository;
+    private final UserRepository userRepository;
 
     @Value("${image.path}")
     private String uploadFolder;
@@ -44,13 +44,14 @@ public class ImageService {
      * @throws Exception
      *          - 파일 저장시 IOException 발생
      */
-    public ImageUploadResDto imageUpload(ImageUploadReqDto imageUploadReqDto/*, long userId*/) throws Exception {
-//        User userEntity = userRepository.findByid(userId).orElseThrow(null);
+    public ImageUploadResDto imageUpload(ImageUploadReqDto imageUploadReqDto, Long userId) throws Exception {
+
+        User user = userRepository.findById(userId)
+               .orElseThrow(() -> new IllegalArgumentException("해당 유저를 찾을 수 없습니다."));
 
         //1. unique 파일명을 생성하기 위해 uuid 사용
         UUID uuid = UUID.randomUUID();
         String imageFileName = uuid + "_" + imageUploadReqDto.getFile().getOriginalFilename();
-        log.info(imageFileName);
         //2. unique 파일명과 upload 위치를 활용해 파일 경로 생성
         Path imageFilePath = Paths.get(uploadFolder).resolve(imageFileName);
 
@@ -64,7 +65,7 @@ public class ImageService {
         }
 
         //4. unique 파일명과 imageUploadReqDto의 값들을 활용해 Entity 객체 생성 후 저장
-        Posts postEntity = imageUploadReqDto.toEntity(imageFileName);
+        Posts postEntity = imageUploadReqDto.toEntity(imageFileName, user);
         Posts post = postsRepository.save(postEntity);
 
         //5. 모든 작업이 완료된 경우 응답 반환
@@ -82,12 +83,17 @@ public class ImageService {
      * @return 성공시 ImageUpdateResDto
      * @exception IllegalArgumentException 게시글을 찾을 수 없을시 발생
      */
-    public ImageUpdateResDto imageUpdate(Long postSeq, ImageUpdateReqDto imageUpdateReqDto) {
+    public ImageUpdateResDto imageUpdate(Long postSeq, ImageUpdateReqDto imageUpdateReqDto, Long userId) {
 
         boolean updated = false;
+
         //1. 게시글 ID를 통해 게시글을 찾아 반환
         Posts posts = postsRepository.findById(postSeq)
                 .orElseThrow(() -> new IllegalArgumentException("게시물을 찾을 수 없습니다"));
+
+        if(!posts.getUser().getId().equals(userId)){
+            throw new IllegalArgumentException("권한이 없는 유저입니다");
+        }
 
         //2. 이미지 수정 여부 파악
         if(imageUpdateReqDto.getFile() != null && !imageUpdateReqDto.getFile().isEmpty()){
@@ -110,7 +116,7 @@ public class ImageService {
             posts.setMediaName(imageFileName);
 
             //2-5. 기존의 파일 삭제
-            Path oldImagePath = Paths.get(uploadFolder + oldFileName);
+            Path oldImagePath = Paths.get(uploadFolder).resolve(oldFileName);
             try{
                 Files.deleteIfExists(oldImagePath);
             } catch (IOException e){
@@ -132,9 +138,6 @@ public class ImageService {
 
         Posts updatedPost;
         if(updated){
-            //4. 업데이트 된 경우 업데이트일시 반영
-            posts.setUpdatedAt(LocalDateTime.now());
-
             //5. 업데이트된 게시글을 DB에 저장
             updatedPost = postsRepository.save(posts);
         }else{
@@ -154,10 +157,14 @@ public class ImageService {
      *
      * @param postSeq 삭제할 게시글 식별자
      */
-    public void imageDelete(Long postSeq) {
+    public void imageDelete(Long postSeq, Long userId) {
         //1. 식별자를 토대로 게시글 찾아 반환
         Posts posts = postsRepository.findById(postSeq)
                         .orElseThrow(() -> new IllegalArgumentException("해당 게시물이 없습니다"));
+
+        if(!posts.getUser().getId().equals(userId)){
+            throw new IllegalArgumentException("권한이 없는 유저입니다");
+        }
 
         //2. 기존에 존재하던 파일 삭제
         Path filePath = Paths.get(uploadFolder).resolve(posts.getMediaName());

--- a/src/main/java/com/goorm/clonestagram/user/domain/User.java
+++ b/src/main/java/com/goorm/clonestagram/user/domain/User.java
@@ -1,6 +1,7 @@
 package com.goorm.clonestagram.user.domain;
 
 
+import com.goorm.clonestagram.common.base.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import lombok.*;

--- a/src/main/java/com/goorm/clonestagram/user/dto/UserProfileDto.java
+++ b/src/main/java/com/goorm/clonestagram/user/dto/UserProfileDto.java
@@ -1,6 +1,8 @@
 package com.goorm.clonestagram.user.dto;
 
+import com.goorm.clonestagram.user.domain.User;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -11,6 +13,7 @@ import java.time.LocalDateTime;
  */
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class UserProfileDto {
     private String username;
@@ -19,4 +22,13 @@ public class UserProfileDto {
     private String profileimg;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    public static UserProfileDto fromEntity(User user) {
+        return UserProfileDto.builder()
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .bio(user.getBio())
+                .profileimg(user.getProfileimg())
+                .build();
+    }
 }

--- a/src/main/java/com/goorm/clonestagram/user/repository/UserRepository.java
+++ b/src/main/java/com/goorm/clonestagram/user/repository/UserRepository.java
@@ -2,8 +2,10 @@ package com.goorm.clonestagram.user.repository;
 
 import com.goorm.clonestagram.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -15,4 +17,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
 
+    //Todo 팔로우 엔티티 추가시 활성화
+//    @Query("SELECT f.toUser.id FROM Follow f WHERE f.fromUser.id = :userId")
+    List<Long> findFollowingUserIdsByFromUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/goorm/clonestagram/user/repository/UserRepository.java
+++ b/src/main/java/com/goorm/clonestagram/user/repository/UserRepository.java
@@ -4,6 +4,8 @@ import com.goorm.clonestagram.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 /**
  * 사용자 정보를 처리하는 리포지토리 인터페이스
  * - 사용자와 관련된 데이터베이스 작업을 수행
@@ -11,5 +13,6 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    User findByUsername(String username);
+    Optional<User> findByUsername(String username);
+
 }

--- a/src/main/java/com/goorm/clonestagram/user/service/ProfileService.java
+++ b/src/main/java/com/goorm/clonestagram/user/service/ProfileService.java
@@ -92,7 +92,7 @@ public class ProfileService {
 
             try {
                 // 이미지 업로드 서비스 호출
-                ImageUploadResDto imageUploadResDto = imageService.imageUpload(imageUploadReqDto);
+                ImageUploadResDto imageUploadResDto = imageService.imageUpload(imageUploadReqDto, user.getId());
 
                 // 이미지 URL 생성 (업로드된 파일 이름을 사용하여 경로 설정)
                 String imageUrl = "/uploads/" + imageUploadResDto.getContent(); // 적합한 경로를 설정

--- a/src/main/java/com/goorm/clonestagram/util/TempUserDetail.java
+++ b/src/main/java/com/goorm/clonestagram/util/TempUserDetail.java
@@ -1,0 +1,42 @@
+package com.goorm.clonestagram.util;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class TempUserDetail implements UserDetails {
+
+    @Override
+    public String getUsername() {
+        return "mockuser";
+    }
+
+    @Override
+    public String getPassword() {
+        return "password";
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return true; }
+
+    public Long getId() {
+        return 1L; // 항상 userId=1인 척
+    }
+}


### PR DESCRIPTION
팔로우 피드 조회 기능

구현 내용

FeedController
- /feeds/follow Get API 엔드포인트 구현
- 페이지 : 20, 생성일시순 정렬

FeedService
- 유저가 팔로우한 모든 유저들 조회
- 팔로우 유저들의 업로드한 게시글 조회

테스트
실제 로그인 기능이 완성되면 테스트 수행